### PR TITLE
Add Cinder volumes for MongoDB and MariaDB

### DIFF
--- a/heat-templates/hot/edx-multi-node.yaml
+++ b/heat-templates/hot/edx-multi-node.yaml
@@ -34,6 +34,15 @@ parameters:
   key_name:
     type: string
     description: keypair for authentication
+  mysql_size:
+    type: string
+    description: Size of MariaDB volumes
+    default: 10
+  mongodb_size:
+    type: string
+    description: Size of MongoDB volumes
+    default: 10
+
 
 resources:
   server_security_group:
@@ -88,7 +97,35 @@ resources:
       router_id: { get_resource: router }
       subnet_id: { get_resource: management_sub_net }
 
-  default_cloud_config:
+  backend_cloud_config:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        package_update: true
+        package_upgrade: true
+        packages:
+          - build-essential
+          - software-properties-common
+          - python-software-properties
+          - curl
+          - git-core
+          - libxml2-dev
+          - libxslt1-dev
+          - python-pip
+          - python-apt
+          - python-dev
+          - xfsprogs
+        runcmd:
+          - mkdir -pv /var/lib/mysql /var/lib/mongodb
+          - echo "/dev/vdb /var/lib/mysql xfs defaults 1 2" >> /etc/fstab
+          - echo "/dev/vdc /var/lib/mongodb xfs defaults 1 2" >> /etc/fstab
+          - while [ ! -e /dev/vdb ]; do sleep 5; done
+          - if ! mount /var/lib/mysql; then mkfs.xfs /dev/vdb && mount /var/lib/mysql; fi
+          - while [ ! -e /dev/vdc ]; do sleep 5; done
+          - if ! mount /var/lib/mongodb; then mkfs.xfs /dev/vdc && mount /var/lib/mongodb; fi
+          - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade virtualenv
+
+  app_cloud_config:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
@@ -169,10 +206,11 @@ resources:
       image: { get_param: image }
       flavor: { get_param: backend_flavor }
       key_name: { get_param: key_name }
-      user_data: { get_resource: default_cloud_config }
+      user_data: { get_resource: backend_cloud_config }
       user_data_format: RAW
       networks:
         - port: { get_resource: backend_a_management_port }
+      block_device_mapping: [{"device_name": "vdb", "volume_id": { get_resource: backend_a_mysql_data }, delete_on_termination: false}, {"device_name": "vdc", "volume_id": { get_resource: backend_a_mongodb_data }, delete_on_termination: false}]
 
   backend_a_management_port:
     type: OS::Neutron::Port
@@ -183,6 +221,16 @@ resources:
       fixed_ips:
         - ip_address: 192.168.122.111
 
+  backend_a_mysql_data:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: mysql_size }
+
+  backend_a_mongodb_data:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: mongodb_size }
+
   backend_b:
     type: OS::Nova::Server
     properties:
@@ -190,10 +238,12 @@ resources:
       image: { get_param: image }
       flavor: { get_param: backend_flavor }
       key_name: { get_param: key_name }
-      user_data: { get_resource: default_cloud_config }
+      user_data: { get_resource: backend_cloud_config }
       user_data_format: RAW
       networks:
         - port: { get_resource: backend_b_management_port }
+      block_device_mapping: [{"device_name": "vdb", "volume_id": { get_resource: backend_b_mysql_data }, delete_on_termination: false}, {"device_name": "vdc", "volume_id": { get_resource: backend_b_mongodb_data }, delete_on_termination: false}]
+
 
   backend_b_management_port:
     type: OS::Neutron::Port
@@ -204,6 +254,16 @@ resources:
       fixed_ips:
         - ip_address: 192.168.122.112
 
+  backend_b_mysql_data:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: mysql_size }
+
+  backend_b_mongodb_data:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: mongodb_size }
+
   backend_c:
     type: OS::Nova::Server
     properties:
@@ -211,10 +271,11 @@ resources:
       image: { get_param: image }
       flavor: { get_param: backend_flavor }
       key_name: { get_param: key_name }
-      user_data: { get_resource: default_cloud_config }
+      user_data: { get_resource: backend_cloud_config }
       user_data_format: RAW
       networks:
         - port: { get_resource: backend_c_management_port }
+      block_device_mapping: [{"device_name": "vdb", "volume_id": { get_resource: backend_c_mysql_data }, delete_on_termination: false}, {"device_name": "vdc", "volume_id": { get_resource: backend_c_mongodb_data }, delete_on_termination: false}]
 
   backend_c_management_port:
     type: OS::Neutron::Port
@@ -224,6 +285,16 @@ resources:
         - { get_resource: server_security_group }
       fixed_ips:
         - ip_address: 192.168.122.113
+
+  backend_c_mysql_data:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: mysql_size }
+
+  backend_c_mongodb_data:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: mongodb_size }
 
   app_servers:
     type: OS::Heat::ResourceGroup
@@ -241,7 +312,7 @@ resources:
           metadata: { "metering.stack": { get_param: "OS::stack_id" } }
           network: { get_resource: management_net }
           security_group: { get_resource: server_security_group }
-          user_data: { get_resource: default_cloud_config }
+          user_data: { get_resource: app_cloud_config }
 
   app_server_monitor:
     type: OS::Neutron::HealthMonitor


### PR DESCRIPTION
Create separate Cinder volumes for both MariaDB and MongoDB on the
backend nodes.  Also format them and mount them on first boot.

This allows administrators to subsequently use Cinder snapshots to back
up the databases.