### PR TITLE
Refactor and streamline Heat templates

### DIFF
--- a/heat-templates/hot/edx-app-server.yaml
+++ b/heat-templates/hot/edx-app-server.yaml
@@ -77,12 +77,14 @@ resources:
           - software-properties-common
           - swig
         runcmd:
+          # Install Open edX prerequisites
           - >
             /usr/bin/pip install --upgrade pip
             && /usr/local/bin/pip install --upgrade setuptools
             && /usr/local/bin/pip install --upgrade virtualenv
           - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+          # Let the calling stack know that we're done
           - { get_param: wait_condition_callback }
 
   # server: an application server instance

--- a/heat-templates/hot/edx-app-server.yaml
+++ b/heat-templates/hot/edx-app-server.yaml
@@ -59,6 +59,8 @@ resources:
         package_update: true
         package_upgrade: true
         packages:
+          # Open edX requires these for installing and combining
+          # Python packages with pip
           - build-essential
           - curl
           - g++-4.8
@@ -75,7 +77,10 @@ resources:
           - software-properties-common
           - swig
         runcmd:
-          - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
+          - >
+            /usr/bin/pip install --upgrade pip
+            && /usr/local/bin/pip install --upgrade setuptools
+            && /usr/local/bin/pip install --upgrade virtualenv
           - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
           - { get_param: wait_condition_callback }

--- a/heat-templates/hot/edx-app-server.yaml
+++ b/heat-templates/hot/edx-app-server.yaml
@@ -1,7 +1,8 @@
 # This template defines an Open edX application server. It is meant to
 # be invoked from an OS::Heat::ResourceGroup. It creates a Nova
 # instance of the defined flavor, and plugs that instance into an
-# LBaaS pool.
+# LBaaS pool. The Nova instance is ephemeral and uses no persistent
+# storage.
 heat_template_version: 2013-05-23
 
 description: >
@@ -13,7 +14,9 @@ parameters:
     description: Name of the server
   image:
     type: string
-    description: Image ID or name. Should be a distribution platform supported for Open edX.
+    description: >
+      Image ID or name.
+      Should be a distribution platform supported for Open edX.
     default: ubuntu-12.04-server-cloudimg
   flavor:
     type: string
@@ -36,7 +39,9 @@ parameters:
     description: Security group used by the server
   key_name:
     type: string
-    description: SSH key name for authentication, to be injected into the server for the default user
+    description: >
+      SSH key name for authentication, to be injected into the server
+      for the default user
   wait_condition_callback:
     type: string
     description: Command to execute at end of initialization

--- a/heat-templates/hot/edx-app-server.yaml
+++ b/heat-templates/hot/edx-app-server.yaml
@@ -32,6 +32,9 @@ parameters:
   key_name:
     type: string
     description: keypair for authentication
+  wait_condition_callback:
+    type: string
+    description: Command to execute at end of initialization
 
 resources:
   app_cloud_config:
@@ -63,6 +66,7 @@ resources:
           - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
           - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+          - { get_param: wait_condition_callback }
 
   server:
     type: OS::Nova::Server

--- a/heat-templates/hot/edx-app-server.yaml
+++ b/heat-templates/hot/edx-app-server.yaml
@@ -1,15 +1,19 @@
+# This template defines an Open edX application server. It is meant to
+# be invoked from an OS::Heat::ResourceGroup. It creates a Nova
+# instance of the defined flavor, and plugs that instance into an
+# LBaaS pool.
 heat_template_version: 2013-05-23
 
 description: >
-  HOT template for an edX app server.
+  Open edX application server
 
 parameters:
   name:
     type: string
-    description: Name of the VM
+    description: Name of the server
   image:
     type: string
-    description: Image ID or name
+    description: Image ID or name. Should be a distribution platform supported for Open edX.
     default: ubuntu-12.04-server-cloudimg
   flavor:
     type: string
@@ -17,12 +21,13 @@ parameters:
     default: m1.large
   pool_id:
     type: string
-    description: Pool to contact
+    description: LBaaS pool to plug the app server into
   protocol_port:
     type: number
-    description: Protocol port
+    description: LBaaS service port number
   metadata:
     type: json
+    description: Metadata injected into the virtual machine
   network:
     type: string
     description: Network used by the server
@@ -31,12 +36,19 @@ parameters:
     description: Security group used by the server
   key_name:
     type: string
-    description: keypair for authentication
+    description: SSH key name for authentication, to be injected into the server for the default user
   wait_condition_callback:
     type: string
     description: Command to execute at end of initialization
 
 resources:
+
+  # app_cloud_config: cloud-init configuration for app servers.
+  #
+  # Installs several packages needed for bootstrapping Open edX.
+  # At the end of the cloud-init sequence, invokes the wait condition
+  # callback to signal to the calling stack that server creation is
+  # complete.
   app_cloud_config:
     type: OS::Heat::CloudConfig
     properties:
@@ -68,6 +80,12 @@ resources:
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
           - { get_param: wait_condition_callback }
 
+  # server: an application server instance
+  #
+  # Creates a new Nova VM with the appropriate flavor and
+  # image. Injects the configured SSH key for the default user,
+  # applies the cloud-init configuration, and plugs the VM into the
+  # correct network using the correct security group.
   server:
     type: OS::Nova::Server
     properties:
@@ -80,6 +98,11 @@ resources:
       user_data_format: RAW
       networks: [ { network: { get_param: network } } ]
       security_groups: [ { get_param: security_group } ]
+
+  # member: a Neutron LBaaS pool member
+  #
+  # Retrieves the primary IP address from the previously created
+  # server, and plugs it into the load balancer pool.
   member:
     type: OS::Neutron::PoolMember
     properties:
@@ -89,8 +112,8 @@ resources:
 
 outputs:
   server_ip:
-    description: IP Address of the load-balanced server.
+    description: "App server's private IP address"
     value: { get_attr: [ server, first_address ] }
   lb_member:
-    description: LB member details.
+    description: Load balancer member details
     value: { get_attr: [ member, show ] }

--- a/heat-templates/hot/edx-app-server.yaml
+++ b/heat-templates/hot/edx-app-server.yaml
@@ -60,20 +60,20 @@ resources:
         package_upgrade: true
         packages:
           - build-essential
-          - software-properties-common
           - curl
+          - g++-4.8
+          - gcc-4.8
           - git-core
+          - libfreetype6-dev
+          - libmysqlclient-dev
           - libxml2-dev
+          - libxmlsec1-dev
           - libxslt1-dev
-          - python-pip
           - python-apt
           - python-dev
-          - libmysqlclient-dev
-          - libxmlsec1-dev
-          - libfreetype6-dev
+          - python-pip
+          - software-properties-common
           - swig
-          - gcc-4.8
-          - g++-4.8
         runcmd:
           - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
           - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50

--- a/heat-templates/hot/edx-app-server.yaml
+++ b/heat-templates/hot/edx-app-server.yaml
@@ -4,6 +4,9 @@ description: >
   HOT template for an edX app server.
 
 parameters:
+  name:
+    type: string
+    description: Name of the VM
   image:
     type: string
     description: Image ID or name
@@ -64,6 +67,7 @@ resources:
   server:
     type: OS::Nova::Server
     properties:
+      name: { get_param: name }
       flavor: { get_param: flavor }
       image: { get_param: image }
       key_name: { get_param: key_name }

--- a/heat-templates/hot/edx-app-server.yaml
+++ b/heat-templates/hot/edx-app-server.yaml
@@ -18,9 +18,6 @@ parameters:
   protocol_port:
     type: number
     description: Protocol port
-  user_data:
-    type: string
-    description: Server user_data
   metadata:
     type: json
   network:
@@ -34,6 +31,36 @@ parameters:
     description: keypair for authentication
 
 resources:
+  app_cloud_config:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        apt_sources:
+          - source: "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main"
+            keyid: BA9EF27F
+        package_update: true
+        package_upgrade: true
+        packages:
+          - build-essential
+          - software-properties-common
+          - curl
+          - git-core
+          - libxml2-dev
+          - libxslt1-dev
+          - python-pip
+          - python-apt
+          - python-dev
+          - libmysqlclient-dev
+          - libxmlsec1-dev
+          - libfreetype6-dev
+          - swig
+          - gcc-4.8
+          - g++-4.8
+        runcmd:
+          - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
+          - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+          - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+
   server:
     type: OS::Nova::Server
     properties:
@@ -41,7 +68,7 @@ resources:
       image: { get_param: image }
       key_name: { get_param: key_name }
       metadata: { get_param: metadata }
-      user_data: { get_param: user_data }
+      user_data: { get_resource: app_cloud_config }
       user_data_format: RAW
       networks: [ { network: { get_param: network } } ]
       security_groups: [ { get_param: security_group } ]

--- a/heat-templates/hot/edx-backend-server.yaml
+++ b/heat-templates/hot/edx-backend-server.yaml
@@ -1,15 +1,21 @@
+# This template defines an Open edX backend server. It is meant to be
+# invoked from an OS::Heat::ResourceGroup. It creates a Nova instance
+# of the defined flavor, and adds two volumes (for MongoDB and
+# MySQL/MariaDB storage).
 heat_template_version: 2013-05-23
 
 description: >
-  HOT template for an edX orchestrated deployment.
+  Open edX backend server
 
 parameters:
   name:
     type: string
-    description: Name of the VM
+    description: Name of the server
   image:
     type: string
-    description: Image ID or name
+    description: >
+      Image ID or name.
+      Should be a distribution platform supported for Open edX.
     default: ubuntu-12.04-server-cloudimg
   flavor:
     type: string
@@ -17,6 +23,7 @@ parameters:
     default: m1.medium
   metadata:
     type: json
+    description: Metadata injected into the virtual machine
   network:
     type: string
     description: Network used by the server
@@ -25,24 +32,32 @@ parameters:
     description: Security group used by the server
   key_name:
     type: string
-    description: keypair for authentication
+    description: >
+      SSH key name for authentication, to be injected into the server
+      for the default user
   mysql_size:
     type: string
-    description: Size of MariaDB volumes
+    description: Size of MariaDB volume
     default: 10
   mongodb_size:
     type: string
-    description: Size of MongoDB volumes
+    description: Size of MongoDB volume
     default: 10
   galera_vip:
     type: string
-    description: VIP for galera.
+    description: Load-balanced virtual IP for MySQL/Galera
     default: 192.168.122.110
   wait_condition_callback:
     type: string
     description: Command to execute at end of initialization
 
 resources:
+  # backend_cloud_config: cloud-init configuration for backend servers.
+  #
+  # Installs several packages needed for bootstrapping Open edX.
+  # At the end of the cloud-init sequence, invokes the wait condition
+  # callback to signal to the calling stack that server creation is
+  # complete.
   backend_cloud_config:
     type: OS::Heat::CloudConfig
     properties:
@@ -102,6 +117,13 @@ resources:
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
           - { get_param: wait_condition_callback }
 
+  # server: an backend server instance
+  #
+  # Creates a new Nova VM with the appropriate flavor and
+  # image. Injects the configured SSH key for the default user,
+  # applies the cloud-init configuration, and plugs the VM into the
+  # correct network using the correct security group. Also adds block
+  # device mappings for the MySQL and MongoDB volumes.
   server:
     type: OS::Nova::Server
     properties:

--- a/heat-templates/hot/edx-backend-server.yaml
+++ b/heat-templates/hot/edx-backend-server.yaml
@@ -38,6 +38,9 @@ parameters:
     type: string
     description: VIP for galera.
     default: 192.168.122.110
+  wait_condition_callback:
+    type: string
+    description: Command to execute at end of initialization
 
 resources:
   backend_cloud_config:
@@ -77,6 +80,7 @@ resources:
           - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
           - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+          - { get_param: wait_condition_callback }
 
   backend_server:
     type: OS::Nova::Server

--- a/heat-templates/hot/edx-backend-server.yaml
+++ b/heat-templates/hot/edx-backend-server.yaml
@@ -53,6 +53,8 @@ resources:
         package_update: true
         package_upgrade: true
         packages:
+          # Open edX requires these for installing and combining
+          # Python packages with pip
           - build-essential
           - curl
           - g++-4.8
@@ -70,6 +72,9 @@ resources:
           - swig
           - xfsprogs
         runcmd:
+          # Create volume filesystems and fstab entries
+          # (waiting for volume attachments to be hot-plugged into the
+          # VM)
           - mkdir -pv /var/lib/mysql /edx/var/mongo/mongodb
           - echo "/dev/vdb /var/lib/mysql xfs defaults 1 2" >> /etc/fstab
           - echo "/dev/vdc /edx/var/mongo/mongodb xfs defaults 1 2" >> /etc/fstab

--- a/heat-templates/hot/edx-backend-server.yaml
+++ b/heat-templates/hot/edx-backend-server.yaml
@@ -1,0 +1,122 @@
+heat_template_version: 2013-05-23
+
+description: >
+  HOT template for an edX orchestrated deployment.
+
+parameters:
+  name:
+    type: string
+    description: Name of the VM
+  image:
+    type: string
+    description: Image ID or name
+    default: ubuntu-12.04-server-cloudimg
+  flavor:
+    type: string
+    description: Flavor to use for backend servers
+    default: m1.medium
+  metadata:
+    type: json
+  network:
+    type: string
+    description: Network used by the server
+  security_group:
+    type: string
+    description: Security group used by the server
+  key_name:
+    type: string
+    description: keypair for authentication
+  mysql_size:
+    type: string
+    description: Size of MariaDB volumes
+    default: 10
+  mongodb_size:
+    type: string
+    description: Size of MongoDB volumes
+    default: 10
+  galera_vip:
+    type: string
+    description: VIP for galera.
+    default: 192.168.122.110
+
+resources:
+  backend_cloud_config:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        apt_sources:
+          - source: "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main"
+            keyid: BA9EF27F
+        package_update: true
+        package_upgrade: true
+        packages:
+          - build-essential
+          - software-properties-common
+          - curl
+          - git-core
+          - libxml2-dev
+          - libxslt1-dev
+          - python-pip
+          - python-apt
+          - python-dev
+          - libmysqlclient-dev
+          - libxmlsec1-dev
+          - libfreetype6-dev
+          - swig
+          - gcc-4.8
+          - g++-4.8
+          - xfsprogs
+        runcmd:
+          - mkdir -pv /var/lib/mysql /edx/var/mongo/mongodb
+          - echo "/dev/vdb /var/lib/mysql xfs defaults 1 2" >> /etc/fstab
+          - echo "/dev/vdc /edx/var/mongo/mongodb xfs defaults 1 2" >> /etc/fstab
+          - while [ ! -e /dev/vdb ]; do sleep 5; done
+          - if ! mount /var/lib/mysql; then mkfs.xfs /dev/vdb && mount /var/lib/mysql; fi
+          - while [ ! -e /dev/vdc ]; do sleep 5; done
+          - if ! mount /edx/var/mongo/mongodb; then mkfs.xfs /dev/vdc && mount /edx/var/mongo/mongodb; fi
+          - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
+          - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+          - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+
+  backend_server:
+    type: OS::Nova::Server
+    properties:
+      name: { get_param: name }
+      image: { get_param: image }
+      flavor: { get_param: flavor }
+      key_name: { get_param: key_name }
+      user_data: { get_resource: backend_cloud_config }
+      user_data_format: RAW
+      networks:
+        - port: { get_resource: backend_management_port }
+      block_device_mapping:
+        - "device_name": "vdb"
+          "volume_id": { get_resource: backend_mysql_data }
+          delete_on_termination: false
+        - "device_name": "vdc"
+          "volume_id": { get_resource: backend_mongodb_data }
+          delete_on_termination: false
+
+  backend_management_port:
+    type: OS::Neutron::Port
+    properties:
+      network_id: { get_param: network }
+      security_groups:
+        - { get_param: security_group }
+      allowed_address_pairs:
+        - ip_address: { get_param: galera_vip }
+
+  backend_mysql_data:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: mysql_size }
+
+  backend_mongodb_data:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: mongodb_size }
+
+outputs:
+  server_ip:
+    description: IP Address of the backend server
+    value: { get_attr: [ backend_server, first_address ] }

--- a/heat-templates/hot/edx-backend-server.yaml
+++ b/heat-templates/hot/edx-backend-server.yaml
@@ -78,11 +78,26 @@ resources:
           - mkdir -pv /var/lib/mysql /edx/var/mongo/mongodb
           - echo "/dev/vdb /var/lib/mysql xfs defaults 1 2" >> /etc/fstab
           - echo "/dev/vdc /edx/var/mongo/mongodb xfs defaults 1 2" >> /etc/fstab
-          - while [ ! -e /dev/vdb ]; do sleep 5; done
-          - if ! mount /var/lib/mysql; then mkfs.xfs /dev/vdb && mount /var/lib/mysql; fi
-          - while [ ! -e /dev/vdc ]; do sleep 5; done
-          - if ! mount /edx/var/mongo/mongodb; then mkfs.xfs /dev/vdc && mount /edx/var/mongo/mongodb; fi
-          - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
+          - >
+            while [ ! -e /dev/vdb ]; do
+              sleep 5;
+            done
+          - >
+            if ! mount /var/lib/mysql; then
+              mkfs.xfs /dev/vdb && mount /var/lib/mysql;
+            fi
+          - >
+            while [ ! -e /dev/vdc ]; do
+              sleep 5;
+            done
+          - >
+            if ! mount /edx/var/mongo/mongodb; then
+              mkfs.xfs /dev/vdc && mount /edx/var/mongo/mongodb;
+            fi
+          - >
+            /usr/bin/pip install --upgrade pip
+            && /usr/local/bin/pip install --upgrade setuptools
+            && /usr/local/bin/pip install --upgrade virtualenv
           - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
           - { get_param: wait_condition_callback }

--- a/heat-templates/hot/edx-backend-server.yaml
+++ b/heat-templates/hot/edx-backend-server.yaml
@@ -54,20 +54,20 @@ resources:
         package_upgrade: true
         packages:
           - build-essential
-          - software-properties-common
           - curl
+          - g++-4.8
+          - gcc-4.8
           - git-core
+          - libfreetype6-dev
+          - libmysqlclient-dev
           - libxml2-dev
+          - libxmlsec1-dev
           - libxslt1-dev
-          - python-pip
           - python-apt
           - python-dev
-          - libmysqlclient-dev
-          - libxmlsec1-dev
-          - libfreetype6-dev
+          - python-pip
+          - software-properties-common
           - swig
-          - gcc-4.8
-          - g++-4.8
           - xfsprogs
         runcmd:
           - mkdir -pv /var/lib/mysql /edx/var/mongo/mongodb

--- a/heat-templates/hot/edx-backend-server.yaml
+++ b/heat-templates/hot/edx-backend-server.yaml
@@ -102,7 +102,7 @@ resources:
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
           - { get_param: wait_condition_callback }
 
-  backend_server:
+  server:
     type: OS::Nova::Server
     properties:
       name: { get_param: name }
@@ -112,16 +112,21 @@ resources:
       user_data: { get_resource: backend_cloud_config }
       user_data_format: RAW
       networks:
-        - port: { get_resource: backend_management_port }
+        - port: { get_resource: management_port }
       block_device_mapping:
         - "device_name": "vdb"
-          "volume_id": { get_resource: backend_mysql_data }
+          "volume_id": { get_resource: mysql_data }
           delete_on_termination: false
         - "device_name": "vdc"
-          "volume_id": { get_resource: backend_mongodb_data }
+          "volume_id": { get_resource: mongodb_data }
           delete_on_termination: false
 
-  backend_management_port:
+  # management_port: the server's network port in the management
+  # network
+  #
+  # Applies the correct security group, and allows the Galera virtual
+  # IP to be configured by an application on this port.
+  management_port:
     type: OS::Neutron::Port
     properties:
       network_id: { get_param: network }
@@ -130,12 +135,14 @@ resources:
       allowed_address_pairs:
         - ip_address: { get_param: galera_vip }
 
-  backend_mysql_data:
+  # mysql_data: persistent storage volume for MySQL/MariaDB data
+  mysql_data:
     type: OS::Cinder::Volume
     properties:
       size: { get_param: mysql_size }
 
-  backend_mongodb_data:
+  # mongodb_data: persistent storage volume for MongoDB data
+  mongodb_data:
     type: OS::Cinder::Volume
     properties:
       size: { get_param: mongodb_size }
@@ -143,4 +150,4 @@ resources:
 outputs:
   server_ip:
     description: IP Address of the backend server
-    value: { get_attr: [ backend_server, first_address ] }
+    value: { get_attr: [ server, first_address ] }

--- a/heat-templates/hot/edx-multi-node.yaml
+++ b/heat-templates/hot/edx-multi-node.yaml
@@ -198,7 +198,6 @@ resources:
           metadata: { "metering.stack": { get_param: "OS::stack_id" } }
           network: { get_resource: management_net }
           security_group: { get_resource: server_security_group }
-          user_data: { get_resource: app_cloud_config }
 
   app_server_monitor:
     type: OS::Neutron::HealthMonitor

--- a/heat-templates/hot/edx-multi-node.yaml
+++ b/heat-templates/hot/edx-multi-node.yaml
@@ -11,7 +11,9 @@ description: >
 parameters:
   image:
     type: string
-    description: Image ID or name
+    description: >
+      Image ID or name.
+      Should be a distribution platform supported for Open edX.
     default: ubuntu-12.04-server-cloudimg
   deploy_flavor:
     type: string
@@ -38,7 +40,9 @@ parameters:
     description: Public network ID
   key_name:
     type: string
-    description: keypair for authentication
+    description: >
+      SSH key name for authentication, to be injected into the servers
+      for the default user
   mysql_size:
     type: string
     description: Size of MariaDB volumes
@@ -203,10 +207,16 @@ resources:
           - software-properties-common
           - swig
         runcmd:
-          - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
+          - >
+            /usr/bin/pip install --upgrade pip
+            && /usr/local/bin/pip install --upgrade setuptools
+            && /usr/local/bin/pip install --upgrade virtualenv
           - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-          - git clone -b "hastexo/master/base" https://github.com/hastexo/edx-configuration /var/tmp/edx-configuration
+          - >
+            git clone -b "hastexo/master/base"
+            https://github.com/hastexo/edx-configuration
+            /var/tmp/edx-configuration
           - /usr/local/bin/pip install -r /var/tmp/edx-configuration/requirements.txt
           - { get_attr: ['deploy_done_handle', 'curl_cli'] }
 

--- a/heat-templates/hot/edx-multi-node.yaml
+++ b/heat-templates/hot/edx-multi-node.yaml
@@ -100,44 +100,6 @@ resources:
       router_id: { get_resource: router }
       subnet_id: { get_resource: management_sub_net }
 
-  backend_cloud_config:
-    type: OS::Heat::CloudConfig
-    properties:
-      cloud_config:
-        apt_sources:
-          - source: "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main"
-            keyid: BA9EF27F
-        package_update: true
-        package_upgrade: true
-        packages:
-          - build-essential
-          - software-properties-common
-          - curl
-          - git-core
-          - libxml2-dev
-          - libxslt1-dev
-          - python-pip
-          - python-apt
-          - python-dev
-          - libmysqlclient-dev
-          - libxmlsec1-dev
-          - libfreetype6-dev
-          - swig
-          - gcc-4.8
-          - g++-4.8
-          - xfsprogs
-        runcmd:
-          - mkdir -pv /var/lib/mysql /edx/var/mongo/mongodb
-          - echo "/dev/vdb /var/lib/mysql xfs defaults 1 2" >> /etc/fstab
-          - echo "/dev/vdc /edx/var/mongo/mongodb xfs defaults 1 2" >> /etc/fstab
-          - while [ ! -e /dev/vdb ]; do sleep 5; done
-          - if ! mount /var/lib/mysql; then mkfs.xfs /dev/vdb && mount /var/lib/mysql; fi
-          - while [ ! -e /dev/vdc ]; do sleep 5; done
-          - if ! mount /edx/var/mongo/mongodb; then mkfs.xfs /dev/vdc && mount /edx/var/mongo/mongodb; fi
-          - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
-          - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
-          - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-
   app_cloud_config:
     type: OS::Heat::CloudConfig
     properties:
@@ -212,10 +174,7 @@ resources:
       networks:
         - port: { get_resource: deploy_management_port }
       metadata:
-        backend_servers:
-          - { get_attr: [ backend_a, first_address ] }
-          - { get_attr: [ backend_b, first_address ] }
-          - { get_attr: [ backend_c, first_address ] }
+        backend_servers: { get_attr: [ backend_servers, server_ip ] }
         app_servers: { get_attr: [ app_servers, server_ip ] }
 
   deploy_management_port:
@@ -234,109 +193,25 @@ resources:
       port_id: { get_resource: deploy_management_port }
       fixed_ip_address: 192.168.122.100
 
-  backend_a:
-    type: OS::Nova::Server
+  backend_servers:
+    type: OS::Heat::ResourceGroup
+    depends_on: management_sub_net
     properties:
-      name: backend_a
-      image: { get_param: image }
-      flavor: { get_param: backend_flavor }
-      key_name: { get_param: key_name }
-      user_data: { get_resource: backend_cloud_config }
-      user_data_format: RAW
-      networks:
-        - port: { get_resource: backend_a_management_port }
-      block_device_mapping: [{"device_name": "vdb", "volume_id": { get_resource: backend_a_mysql_data }, delete_on_termination: false}, {"device_name": "vdc", "volume_id": { get_resource: backend_a_mongodb_data }, delete_on_termination: false}]
-
-  backend_a_management_port:
-    type: OS::Neutron::Port
-    properties:
-      network_id: { get_resource: management_net }
-      security_groups:
-        - { get_resource: server_security_group }
-      allowed_address_pairs:
-        - ip_address: { get_param: galera_vip }
-      fixed_ips:
-        - ip_address: 192.168.122.111
-
-  backend_a_mysql_data:
-    type: OS::Cinder::Volume
-    properties:
-      size: { get_param: mysql_size }
-
-  backend_a_mongodb_data:
-    type: OS::Cinder::Volume
-    properties:
-      size: { get_param: mongodb_size }
-
-  backend_b:
-    type: OS::Nova::Server
-    properties:
-      name: backend_b
-      image: { get_param: image }
-      flavor: { get_param: backend_flavor }
-      key_name: { get_param: key_name }
-      user_data: { get_resource: backend_cloud_config }
-      user_data_format: RAW
-      networks:
-        - port: { get_resource: backend_b_management_port }
-      block_device_mapping: [{"device_name": "vdb", "volume_id": { get_resource: backend_b_mysql_data }, delete_on_termination: false}, {"device_name": "vdc", "volume_id": { get_resource: backend_b_mongodb_data }, delete_on_termination: false}]
-
-
-  backend_b_management_port:
-    type: OS::Neutron::Port
-    properties:
-      network_id: { get_resource: management_net }
-      security_groups:
-        - { get_resource: server_security_group }
-      allowed_address_pairs:
-        - ip_address: { get_param: galera_vip }
-      fixed_ips:
-        - ip_address: 192.168.122.112
-
-  backend_b_mysql_data:
-    type: OS::Cinder::Volume
-    properties:
-      size: { get_param: mysql_size }
-
-  backend_b_mongodb_data:
-    type: OS::Cinder::Volume
-    properties:
-      size: { get_param: mongodb_size }
-
-  backend_c:
-    type: OS::Nova::Server
-    properties:
-      name: backend_c
-      image: { get_param: image }
-      flavor: { get_param: backend_flavor }
-      key_name: { get_param: key_name }
-      user_data: { get_resource: backend_cloud_config }
-      user_data_format: RAW
-      networks:
-        - port: { get_resource: backend_c_management_port }
-      block_device_mapping: [{"device_name": "vdb", "volume_id": { get_resource: backend_c_mysql_data }, delete_on_termination: false}, {"device_name": "vdc", "volume_id": { get_resource: backend_c_mongodb_data }, delete_on_termination: false}]
-
-  backend_c_management_port:
-    type: OS::Neutron::Port
-    properties:
-      network_id: { get_resource: management_net }
-      security_groups:
-        - { get_resource: server_security_group }
-      allowed_address_pairs:
-        - ip_address: { get_param: galera_vip }
-      fixed_ips:
-        - ip_address: 192.168.122.113
-
-  backend_c_mysql_data:
-    type: OS::Cinder::Volume
-    properties:
-      size: { get_param: mysql_size }
-
-  backend_c_mongodb_data:
-    type: OS::Cinder::Volume
-    properties:
-      size: { get_param: mongodb_size }
-
+      count: 3
+      resource_def:
+        type: edx-backend-server.yaml
+        properties:
+          name: backend%index%
+          flavor: { get_param: backend_flavor }
+          image: { get_param: image }
+          key_name: { get_param: key_name }
+          metadata: { "metering.stack": { get_param: "OS::stack_id" } }
+          network: { get_resource: management_net }
+          security_group: { get_resource: server_security_group }
+          mysql_size: { get_param: mysql_size }
+          mongodb_size: { get_param: mongodb_size }
+          galera_vip: { get_param: galera_vip }
+      
   app_servers:
     type: OS::Heat::ResourceGroup
     depends_on: management_sub_net

--- a/heat-templates/hot/edx-multi-node.yaml
+++ b/heat-templates/hot/edx-multi-node.yaml
@@ -190,6 +190,7 @@ resources:
       resource_def:
         type: edx-app-server.yaml
         properties:
+          name: app%index%
           flavor: { get_param: app_flavor }
           image: { get_param: image }
           key_name: { get_param: key_name }

--- a/heat-templates/hot/edx-multi-node.yaml
+++ b/heat-templates/hot/edx-multi-node.yaml
@@ -145,20 +145,20 @@ resources:
         package_upgrade: true
         packages:
           - build-essential
-          - software-properties-common
           - curl
+          - g++-4.8
+          - gcc-4.8
           - git-core
+          - libfreetype6-dev
+          - libmysqlclient-dev
           - libxml2-dev
+          - libxmlsec1-dev
           - libxslt1-dev
-          - python-pip
           - python-apt
           - python-dev
-          - libmysqlclient-dev
-          - libxmlsec1-dev
-          - libfreetype6-dev
+          - python-pip
+          - software-properties-common
           - swig
-          - gcc-4.8
-          - g++-4.8
         runcmd:
           - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
           - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50

--- a/heat-templates/hot/edx-multi-node.yaml
+++ b/heat-templates/hot/edx-multi-node.yaml
@@ -46,8 +46,42 @@ parameters:
     type: string
     description: VIP for galera.
     default: 192.168.122.110
+  timeout:
+    type: number
+    description: Stack creation timeout (seconds)
+    default: 900
 
 resources:
+  deploy_done:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: {get_resource: deploy_done_handle}
+      count: 1
+      timeout: {get_param: timeout}
+
+  deploy_done_handle:
+    type: OS::Heat::WaitConditionHandle
+
+  backend_done:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: {get_resource: backend_done_handle}
+      count: 3
+      timeout: {get_param: timeout}
+
+  app_done_handle:
+    type: OS::Heat::WaitConditionHandle
+
+  app_done:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: {get_resource: app_done_handle}
+      count: { get_param: app_count }
+      timeout: {get_param: timeout}
+
+  backend_done_handle:
+    type: OS::Heat::WaitConditionHandle
+
   server_security_group:
     type: OS::Neutron::SecurityGroup
     properties:
@@ -131,6 +165,7 @@ resources:
           - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
           - git clone -b "hastexo/master/base" https://github.com/hastexo/edx-configuration /var/tmp/edx-configuration
           - /usr/local/bin/pip install -r /var/tmp/edx-configuration/requirements.txt
+          - { get_attr: ['deploy_done_handle', 'curl_cli'] }
 
   deploy:
     type: OS::Nova::Server
@@ -181,6 +216,7 @@ resources:
           mysql_size: { get_param: mysql_size }
           mongodb_size: { get_param: mongodb_size }
           galera_vip: { get_param: galera_vip }
+          wait_condition_callback: { get_attr: ['backend_done_handle', 'curl_cli'] }
       
   app_servers:
     type: OS::Heat::ResourceGroup
@@ -199,6 +235,7 @@ resources:
           metadata: { "metering.stack": { get_param: "OS::stack_id" } }
           network: { get_resource: management_net }
           security_group: { get_resource: server_security_group }
+          wait_condition_callback: { get_attr: ['app_done_handle', 'curl_cli'] }
 
   app_server_monitor:
     type: OS::Neutron::HealthMonitor

--- a/heat-templates/hot/edx-multi-node.yaml
+++ b/heat-templates/hot/edx-multi-node.yaml
@@ -100,36 +100,6 @@ resources:
       router_id: { get_resource: router }
       subnet_id: { get_resource: management_sub_net }
 
-  app_cloud_config:
-    type: OS::Heat::CloudConfig
-    properties:
-      cloud_config:
-        apt_sources:
-          - source: "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main"
-            keyid: BA9EF27F
-        package_update: true
-        package_upgrade: true
-        packages:
-          - build-essential
-          - software-properties-common
-          - curl
-          - git-core
-          - libxml2-dev
-          - libxslt1-dev
-          - python-pip
-          - python-apt
-          - python-dev
-          - libmysqlclient-dev
-          - libxmlsec1-dev
-          - libfreetype6-dev
-          - swig
-          - gcc-4.8
-          - g++-4.8
-        runcmd:
-          - /usr/bin/pip install --upgrade pip && /usr/local/bin/pip install --upgrade setuptools && /usr/local/bin/pip install --upgrade virtualenv
-          - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
-          - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-
   deploy_cloud_config:
     type: OS::Heat::CloudConfig
     properties:

--- a/heat-templates/hot/edx-multi-node.yaml
+++ b/heat-templates/hot/edx-multi-node.yaml
@@ -1,7 +1,12 @@
+# This template defines a full Open edX environment. It creates a
+# single deployment node, 3 backend servers backed by persistent
+# volumes, a configurable number of ephemeral application servers, and
+# a load balancing pool behind a floating IP.
 heat_template_version: 2013-05-23
 
 description: >
-  HOT template for an edX orchestrated deployment.
+  Full Open edX deployment: 3 backend nodes, configurable
+  number of application servers behind a load balancer.
 
 parameters:
   image:
@@ -44,7 +49,7 @@ parameters:
     default: 10
   galera_vip:
     type: string
-    description: VIP for galera.
+    description: Load-balanced virtual IP for MySQL/Galera
     default: 192.168.122.110
   timeout:
     type: number
@@ -52,6 +57,8 @@ parameters:
     default: 900
 
 resources:
+  # deploy_done: Wait condition to signal that the deploy node has
+  # completed its installation.
   deploy_done:
     type: OS::Heat::WaitCondition
     properties:
@@ -62,6 +69,11 @@ resources:
   deploy_done_handle:
     type: OS::Heat::WaitConditionHandle
 
+  # backend_done: Wait condition to signal that a backend node has
+  # completed its installation.
+  #
+  # We always run on 3 backend nodes, hence, we wait for this signal
+  # to be received 3 times.
   backend_done:
     type: OS::Heat::WaitCondition
     properties:
@@ -69,9 +81,14 @@ resources:
       count: 3
       timeout: {get_param: timeout}
 
-  app_done_handle:
+  backend_done_handle:
     type: OS::Heat::WaitConditionHandle
 
+  # app_done: Wait condition to signal that an app server has
+  # completed its installation.
+  #
+  # We run on app_count app server nodes, hence, we wait for this
+  # signal to be received app_count times.
   app_done:
     type: OS::Heat::WaitCondition
     properties:
@@ -79,9 +96,14 @@ resources:
       count: { get_param: app_count }
       timeout: {get_param: timeout}
 
-  backend_done_handle:
+  app_done_handle:
     type: OS::Heat::WaitConditionHandle
 
+  # server_security_group: Neutron security group allowing inbound
+  # access on selected ports
+  #
+  # We allow inbound ICMP, SSH, and TCP on whatever was set as the
+  # app_port.
   server_security_group:
     type: OS::Neutron::SecurityGroup
     properties:
@@ -104,11 +126,17 @@ resources:
         port_range_min: { get_param: app_port }
         port_range_max: { get_param: app_port }
 
+  # management_net: private Neutron network
   management_net:
     type: OS::Neutron::Net
     properties:
       name: management-net
 
+  # management_sub_net: private Neutron subnet
+  #
+  # We assign dynamic private (fixed) IPv4 addresses upward of
+  # 192.168.122.200. Any statically configured addresses in this
+  # subnet must use IP addresses below .200.
   management_sub_net:
     type: OS::Neutron::Subnet
     properties:
@@ -119,21 +147,36 @@ resources:
       enable_dhcp: true
       allocation_pools: [ { "start": "192.168.122.200", "end": "192.168.122.254" } ]
 
+  # router: private router
+  #
+  # Connects our private subnet to the floating IP network.
   router:
     type: OS::Neutron::Router
 
+  # router_gateway
+  #
+  # Sets the public network as the router's gateway.
   router_gateway:
     type: OS::Neutron::RouterGateway
     properties:
       router_id: { get_resource: router }
       network_id: { get_param: public_net_id }
 
+  # router_interface
+  #
+  # Plugs the management subnet into the router.
   router_interface:
     type: OS::Neutron::RouterInterface
     properties:
       router_id: { get_resource: router }
       subnet_id: { get_resource: management_sub_net }
 
+  # deploy_cloud_config: cloud-init configuration for deploy node
+  #
+  # Installs several packages needed for bootstrapping Open edX.
+  # At the end of the cloud-init sequence, invokes the wait condition
+  # callback to signal to the calling stack that server creation is
+  # complete.
   deploy_cloud_config:
     type: OS::Heat::CloudConfig
     properties:
@@ -167,6 +210,14 @@ resources:
           - /usr/local/bin/pip install -r /var/tmp/edx-configuration/requirements.txt
           - { get_attr: ['deploy_done_handle', 'curl_cli'] }
 
+  # deploy: the deploy node instance
+  #
+  # Creates a new Nova VM with the appropriate flavor and
+  # image. Injects the configured SSH key for the default user,
+  # applies the cloud-init configuration, and plugs the VM into the
+  # correct network using the correct security group. Also, provides
+  # metadata about backend and app servers to be parsed by the Ansible
+  # dynamic inventory script (inventory.py).
   deploy:
     type: OS::Nova::Server
     properties:
@@ -182,6 +233,11 @@ resources:
         backend_servers: { get_attr: [ backend_servers, server_ip ] }
         app_servers: { get_attr: [ app_servers, server_ip ] }
 
+  # deploy_management_port: the deploy node's network port in the
+  # management network
+  #
+  # Applies the correct security group, and sets a hard-coded fixed
+  # IP address.
   deploy_management_port:
     type: OS::Neutron::Port
     properties:
@@ -191,13 +247,18 @@ resources:
       fixed_ips:
         - ip_address: 192.168.122.100
 
+  # deploy_floating_ip: floating IP address for the deploy node
+  #
+  # Makes the deploy node accessible via a floating IP address.
   deploy_floating_ip:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network_id: { get_param: public_net_id }
       port_id: { get_resource: deploy_management_port }
-      fixed_ip_address: 192.168.122.100
 
+  # backend_servers: creates a backend cluster of 3 nodes
+  #
+  # Backend servers are named backend0, backend1, backend2.
   backend_servers:
     type: OS::Heat::ResourceGroup
     depends_on: management_sub_net
@@ -218,6 +279,10 @@ resources:
           galera_vip: { get_param: galera_vip }
           wait_condition_callback: { get_attr: ['backend_done_handle', 'curl_cli'] }
       
+  # app_servers: creates an application server cluster of a
+  # configurable size
+  #
+  # App servers are named app0 ... appN, where N == app_count - 1.
   app_servers:
     type: OS::Heat::ResourceGroup
     depends_on: management_sub_net
@@ -237,6 +302,7 @@ resources:
           security_group: { get_resource: server_security_group }
           wait_condition_callback: { get_attr: ['app_done_handle', 'curl_cli'] }
 
+  # app_server_monitor: Neutron LBaaS monitor
   app_server_monitor:
     type: OS::Neutron::HealthMonitor
     properties:
@@ -245,6 +311,9 @@ resources:
       max_retries: 5
       timeout: 5
 
+  # app_server_pool: Neutron LBaaS pool
+  #
+  # Defines a private virtual IP (VIP) front end on the app port.
   app_server_pool:
     type: OS::Neutron::Pool
     properties:
@@ -257,12 +326,17 @@ resources:
       monitors: [ { get_resource: app_server_monitor } ]
       subnet_id: { get_resource: management_sub_net }
 
+  # app_server_floating_ip: Neutron LBaaS floating IP address
+  #
+  # Defines a floating IP address linked to the load balancer's
+  # private virtual IP (VIP).
   app_server_floating_ip:
     type: OS::Neutron::FloatingIP
     properties:
       floating_network_id: { get_param: public_net_id }
       port_id: { get_attr: [ app_server_pool, vip, port_id ] }
 
+  # app_server_lb: Neutron LBaaS load balancer
   app_server_lb:
     type: OS::Neutron::LoadBalancer
     properties:


### PR DESCRIPTION
- Rather than specifying backend servers explicitly in the main multi-node template, put them into their own template and spin them up via a ResourceGroup.
- Name VMs `backend0`, `backend1`, `backend2`, `app0`, `app1` etc. using the `%index%` property.
- Stop assigning fixed IPs manually.
- Add WaitConditions and WaitConditionHandles
- Improve documentation