### PR TITLE
Fix certbot-renew-hook to set correct environment variable

### DIFF
--- a/playbooks/roles/certbot/templates/certbot-renew-hook.j2
+++ b/playbooks/roles/certbot/templates/certbot-renew-hook.j2
@@ -13,4 +13,4 @@ sudo -Hu ${PLAYBOOK_USER} ansible-playbook run_role.yml \
         -l ${PLAYBOOK_TARGET} \
         -e role=certbot_deploy \
         -e certbot_deploy=True \
-        -e certbot_cert_name=${RENEWED_LINEAGE}
+        -e certbot_cert_dir=${RENEWED_LINEAGE}


### PR DESCRIPTION
The certbot-renew-hook should set certbot_cert_dir, not certbot_cert_name, to the ${RENEWED_LINEAGE} shell variable received from certbot. Otherwise, the playbook invoked by the renew hook does run, it just does not deploy any new certs and also does not restart nginx.