### PR TITLE
Add additional explicit dependencies in Heat template

### DIFF
--- a/heat-templates/hot-2016-04-08/edx-multi-node.yaml
+++ b/heat-templates/hot-2016-04-08/edx-multi-node.yaml
@@ -351,7 +351,8 @@ resources:
   # App servers are named app0 ... appN, where N == app_count - 1.
   app_servers:
     type: OS::Heat::ResourceGroup
-    depends_on: management_sub_net
+    depends_on:
+      - management_sub_net
     properties:
       count: { get_param: app_count }
       resource_def:
@@ -375,6 +376,8 @@ resources:
     type: OS::Neutron::LBaaS::LoadBalancer
     properties:
       vip_subnet: { get_resource: management_sub_net }
+    depends_on:
+      - management_sub_net
 
   app_server_http_listener:
     type: OS::Neutron::LBaaS::Listener
@@ -396,6 +399,8 @@ resources:
       lb_algorithm: LEAST_CONNECTIONS
       listener: { get_resource: app_server_http_listener }
       protocol: TCP
+    depends_on:
+      - app_server_lb
 
   app_server_https_pool:
     type: OS::Neutron::LBaaS::Pool
@@ -403,6 +408,8 @@ resources:
       lb_algorithm: LEAST_CONNECTIONS
       listener: { get_resource: app_server_https_listener }
       protocol: TCP
+    depends_on:
+      - app_server_lb
 
   app_server_http_monitor:
     type: OS::Neutron::LBaaS::HealthMonitor


### PR DESCRIPTION
Make the LBaaS pools explicitly depends on the load balancer. This shouldn't be necessary, as there is already an indirect dependency via the listener, but we've seen Heat misbehave on stack deletion, trying
to remove the load balancer before the pool is gone. Adding the explicit dependencies ensures that upon deletion, the pools are deleted before Heat deletes the load balancer.
