### PR TITLE
Add mechanism to disable hastexo_xblock services

### DIFF
--- a/playbooks/roles/hastexo_xblock/tasks/main.yml
+++ b/playbooks/roles/hastexo_xblock/tasks/main.yml
@@ -58,6 +58,26 @@
     - suspender
     - reaper
 
+- name: "Stop supervisor services"
+  shell:  "{{ supervisor_ctl }} -c {{ supervisor_cfg }} stop {{ item }}:"
+  with_items:
+    - suspender
+    - reaper
+  when: disable_edx_services
+  tags:
+    - manage
+
+- name: "Disable supervisor scripts"
+  file:
+    path: "{{ supervisor_cfg_dir }}/{{ item }}.conf"
+    state: absent
+  with_items:
+    - suspender
+    - reaper
+  when: disable_edx_services
+  tags:
+    - manage
+
 - name: "Enable supervisor scripts"
   file:
     src: "{{ supervisor_available_dir }}/{{ item }}.conf"
@@ -71,12 +91,15 @@
     - suspender
     - reaper
   when: not disable_edx_services
+  tags:
+    - manage
 
 - name: Update supervisor configuration
   shell:  "{{ supervisor_ctl }} -c {{ supervisor_cfg }} update"
   register: supervisor_update
   changed_when: supervisor_update.stdout is defined and supervisor_update.stdout != ""
-  when: not disable_edx_services
+  tags:
+    - manage
 
 - name: Restart supervisor services
   shell:  "{{ supervisor_ctl }} -c {{ supervisor_cfg }} restart {{ item }}:"
@@ -84,3 +107,5 @@
     - suspender
     - reaper
   when: not disable_edx_services
+  tags:
+    - manage


### PR DESCRIPTION
Copy the edxapp service management mechanism to disable services, so
that running the following disables the reaper and suspender on a
running stack:

```
ansible-playbook run_role.yaml -e role=hastexo_xblock \
	-e disable_edx_services=true \
	--tags manage
```