### PR TITLE
Trim services

### DIFF
--- a/playbooks/hastexo-multi-node.yml
+++ b/playbooks/hastexo-multi-node.yml
@@ -35,13 +35,11 @@
       nginx_sites:
       - cms
       - lms
-      - forum
       nginx_default_sites:
       - lms
     - role: edxapp
       celery_worker: True
     - edxapp
-    - forum
     - role: notifier
       NOTIFIER_DIGEST_TASK_INTERVAL: "5"
     - role: postfix

--- a/playbooks/hastexo-multi-node.yml
+++ b/playbooks/hastexo-multi-node.yml
@@ -36,7 +36,6 @@
       - cms
       - lms
       - forum
-      - xqueue
       nginx_default_sites:
       - lms
     - role: edxapp
@@ -45,8 +44,6 @@
     - forum
     - role: notifier
       NOTIFIER_DIGEST_TASK_INTERVAL: "5"
-    - role: xqueue
-      update_users: True
     - role: postfix
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST is not defined or POSTFIX_QUEUE_EXTERNAL_SMTP_HOST == ''
     - role: postfix_queue

--- a/playbooks/hastexo-multi-node.yml
+++ b/playbooks/hastexo-multi-node.yml
@@ -40,8 +40,6 @@
     - role: edxapp
       celery_worker: True
     - edxapp
-    - role: notifier
-      NOTIFIER_DIGEST_TASK_INTERVAL: "5"
     - role: postfix
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST is not defined or POSTFIX_QUEUE_EXTERNAL_SMTP_HOST == ''
     - role: postfix_queue

--- a/playbooks/hastexo-multi-node.yml
+++ b/playbooks/hastexo-multi-node.yml
@@ -33,7 +33,6 @@
     - supervisor
     - role: nginx
       nginx_sites:
-      - certs
       - cms
       - lms
       - forum
@@ -48,7 +47,6 @@
       NOTIFIER_DIGEST_TASK_INTERVAL: "5"
     - role: xqueue
       update_users: True
-    - certs
     - role: postfix
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST is not defined or POSTFIX_QUEUE_EXTERNAL_SMTP_HOST == ''
     - role: postfix_queue


### PR DESCRIPTION
Remove unneeded roles from the hastexo playbooks, so that we no longer deploy them on our platforms. These changes remove

* certs,
* xqueue,
* forum,
* notifier.