### PR TITLE
Remove dependency on Ansible venv

### DIFF
--- a/playbooks/roles/certbot/templates/certbot-deploy-hook.j2
+++ b/playbooks/roles/certbot/templates/certbot-deploy-hook.j2
@@ -8,6 +8,10 @@ ANSIBLE_BIN={{ edx_ansible_venv_bin }}
 
 sudo -Hu ${PLAYBOOK_USER} sh <<EOF
 cd ${PLAYBOOK_DIR}
-. ${ANSIBLE_BIN}/activate
-${ANSIBLE_BIN}/ansible-playbook certbot-deploy-hook.yml
+if [ -d "${ANSIBLE_BIN}" ]; then
+  . ${ANSIBLE_BIN}/activate
+  ${ANSIBLE_BIN}/ansible-playbook certbot-deploy-hook.yml
+else
+  ansible-playbook certbot-deploy-hook.yml
+fi
 EOF


### PR DESCRIPTION
Now that we can no longer rely on the assumption that ansible runs
in a venv, remove the dependency on the venv directory.

Thus, if the venv does not exist, just assume that ansible-playbook
is in the PATH, and run from there.