### PR TITLE
guacd: stop assuming version includes "-incubating"

### DIFF
--- a/playbooks/roles/guacd/defaults/main.yml
+++ b/playbooks/roles/guacd/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-guacd_version: 0.9.13
+guacd_version: 0.9.13-incubating
 guacd_mirror: http://archive.apache.org/dist

--- a/playbooks/roles/guacd/tasks/main.yml
+++ b/playbooks/roles/guacd/tasks/main.yml
@@ -19,28 +19,28 @@
 
 - name: Get server tarball
   get_url:
-    url: "{{ guacd_mirror }}/guacamole/{{ guacd_version }}-incubating/source/guacamole-server-{{ guacd_version }}-incubating.tar.gz"
+    url: "{{ guacd_mirror }}/guacamole/{{ guacd_version }}/source/guacamole-server-{{ guacd_version }}.tar.gz"
     dest: /tmp
 
 - name: Extract server tarball
   unarchive:
     remote_src: yes
-    src: /tmp/guacamole-server-{{ guacd_version }}-incubating.tar.gz
+    src: /tmp/guacamole-server-{{ guacd_version }}.tar.gz
     dest: /tmp
 
 - name: Configure server
   command: ./configure --with-init-dir=/etc/init.d
   args:
-    chdir: /tmp/guacamole-server-{{ guacd_version }}-incubating
+    chdir: /tmp/guacamole-server-{{ guacd_version }}
 
 - name: Compile server
   make:
-    chdir: /tmp/guacamole-server-{{ guacd_version }}-incubating
+    chdir: /tmp/guacamole-server-{{ guacd_version }}
 
 - name: Install server
   make:
     target: install
-    chdir: /tmp/guacamole-server-{{ guacd_version }}-incubating
+    chdir: /tmp/guacamole-server-{{ guacd_version }}
 
 - name: Symlink freerdp libraries
   file:


### PR DESCRIPTION
It was pretty silly from the beginning to assume that guacd's version identifier was always going to include `-incubating`.

Drop that hardcoded suffix from the tasks, but for backward compatibility retain it in the variable default (for now).
