### PR TITLE
Workaround for broken BLOCKSTORE_DATABASE_CONN_MAX_AGE

### DIFF
--- a/playbooks/roles/blockstore/meta/main.yml
+++ b/playbooks/roles/blockstore/meta/main.yml
@@ -27,7 +27,8 @@ dependencies:
     edx_django_service_db_password: '{{ BLOCKSTORE_DATABASE_PASSWORD }}'
     edx_django_service_default_db_host: '{{ BLOCKSTORE_DATABASE_HOST }}'
     edx_django_service_default_db_atomic_requests: true
-    edx_django_service_default_db_conn_max_age: '{{ BLOCKSTORE_DATABASE_CONN_MAX_AGE }}'
+    # Don't set edx_django_service_default_db_conn_max_age, see
+    # https://discuss.openedx.org/t/running-blockstore-in-juniper/2625/4
     edx_django_service_django_settings_module: '{{ BLOCKSTORE_DJANGO_SETTINGS_MODULE }}'
     edx_django_service_secret_key: '{{ BLOCKSTORE_SECRET_KEY }}'
     edx_django_service_automated_users: '{{ BLOCKSTORE_AUTOMATED_USERS }}'


### PR DESCRIPTION
Setting the blockstore `edx_django_service_default_db_conn_max_age` to a quoted value leads to perpetual HTTP 500s from Blockstore, due to an incorrectly-typed `CONN_MAX_AGE` setting in the resulting configuration.

See:
https://discuss.openedx.org/t/running-blockstore-in-juniper/2625/4

Use the default set in `edx_django_service` instead, which is correctly typed.
