### PR TITLE
Fix environment variables in suspender/reaper supervisor definitions

### DIFF
--- a/playbooks/roles/hastexo_xblock/templates/reaper.conf.j2
+++ b/playbooks/roles/hastexo_xblock/templates/reaper.conf.j2
@@ -4,7 +4,9 @@ command=/edx/bin/python.edxapp {{ edxapp_code_dir }}/manage.py lms --settings={{
 
 user={{ common_web_user }}
 directory={{ edxapp_code_dir }}
-environment=LANG={{ EDXAPP_LANG }},DJANGO_SETTINGS_MODULE={{ EDXAPP_LMS_ENV }},SERVICE_VARIANT="lms",PATH="{{ edxapp_deploy_path }}"
+{# preserve the newline after this for loop, otherwise we end up with an environment variable named "stdout_logfile", which we don't want #}
+environment={% for name,value in edxapp_environment.items() %}{%- if value %}{{ name }}="{{ value }}"{%- endif %},{% endfor %}
+
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true

--- a/playbooks/roles/hastexo_xblock/templates/suspender.conf.j2
+++ b/playbooks/roles/hastexo_xblock/templates/suspender.conf.j2
@@ -4,7 +4,9 @@ command=/edx/bin/python.edxapp {{ edxapp_code_dir }}/manage.py lms --settings={{
 
 user={{ common_web_user }}
 directory={{ edxapp_code_dir }}
-environment=LANG={{ EDXAPP_LANG }},DJANGO_SETTINGS_MODULE={{ EDXAPP_LMS_ENV }},SERVICE_VARIANT="lms",PATH="{{ edxapp_deploy_path }}"
+{# preserve the newline after this for loop, otherwise we end up with an environment variable named "stdout_logfile", which we don't want #}
+environment={% for name,value in edxapp_environment.items() %}{%- if value %}{{ name }}="{{ value }}"{%- endif %},{% endfor %}
+
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true


### PR DESCRIPTION
Juniper expects a different set of environment variables in supervisor jobs than Ironwood did. Using the old set of variables means we're missing `LMS_CFG` and `REVISION_CFG`, causing the suspender and reaper supervisor jobs to fail on startup.

Use a modified form of the loop from [the template that the edxapp role uses to populate edxapp_env](https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/templates/edxapp_env.j2), in order to set the correct variables.
