### PR TITLE
Back out blockstore

### DIFF
--- a/playbooks/hastexo-multi-node.yml
+++ b/playbooks/hastexo-multi-node.yml
@@ -37,7 +37,6 @@
       - lms
       nginx_default_sites:
       - lms
-      - blockstore
     - role: edxapp
       celery_worker: True
     - edxapp
@@ -47,7 +46,6 @@
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
     - guacd
     - hastexo_xblock
-    - blockstore
 
 - name: Stop all services on app master
   hosts: app_master

--- a/playbooks/hastexo-single-node.yml
+++ b/playbooks/hastexo-single-node.yml
@@ -17,7 +17,6 @@
       - xqueue
       nginx_default_sites:
       - lms
-      - blockstore
     - edxlocal
     - memcache
     - mongo_3_6
@@ -33,4 +32,3 @@
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
     - guacd
     - hastexo_xblock
-    - blockstore


### PR DESCRIPTION
We've found that for the time being (i.e. for the Juniper release), Blockstore is not in a shape that we find useful, nor does it solve
any actual problem we're having. Thus, back it out of our playbooks until we've been able to reassess its utility.

This reverts commit 29162410a71a358e809f1cad67ff98890e019395.