### PR TITLE
Use a negated "is skipped" check for mariadb_new_debian_cnf

### DIFF
--- a/playbooks/roles/mariadb/tasks/cluster.yml
+++ b/playbooks/roles/mariadb/tasks/cluster.yml
@@ -32,7 +32,7 @@
 
 - name: copy fetched file to other cluster members
   copy: src=/tmp/debian.cnf dest=/etc/mysql/debian.cnf
-  when: mariadb_new_debian_cnf is defined
+  when: not (mariadb_new_debian_cnf is skipped)
 
 - name: start everything
   service: name=mysql state=started


### PR DESCRIPTION
This PR updates our integration branch with a new commit in the `hastexo/juniper/fix_mariadb` branch:

The `copy fetched file to other cluster members` task uses an `is defined` test on the `mariadb_new_debian_cnf` fact to determine whether the preceding `fetch debian.cnf file so start-stop will work properly` task ran or not.

`is defined` is the wrong test to use here. As [the Ansible documentation](https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#conditions-based-on-registered-variables) explains, if a task registers a variable, an `is defined` test on a subsequent task will always return `true`, even if the task has been skipped. Thus, we instead need to check with `is skipped` to see if the task has been skipped (and in this case, we want the reverse, so we negate the test).