### PR TITLE
postfix_queue: Add the ability to populate Postfix recipient maps

### DIFF
--- a/playbooks/roles/postfix_queue/defaults/main.yml
+++ b/playbooks/roles/postfix_queue/defaults/main.yml
@@ -26,6 +26,13 @@ POSTFIX_QUEUE_HOSTNAME: ''
 #   someuser@example.com otheruser@myschool.org
 POSTFIX_QUEUE_SENDER_CANONICAL_MAPS: ''
 
+# Set this to content of recipient_canonical_maps postfix configuration file (optional).
+# Example:
+# POSTFIX_QUEUE_RECIPIENT_CANONICAL_MAPS: |-
+#   @internal @external.com
+#   someuser@example.com otheruser@myschool.org
+POSTFIX_QUEUE_RECIPIENT_CANONICAL_MAPS: ''
+
 # Set this to content of header_checks postfix configuration file (optional).
 # Example:
 # POSTFIX_QUEUE_HEADER_CHECKS: |-
@@ -37,6 +44,7 @@ POSTFIX_QUEUE_HEADER_CHECKS: ''
 
 postfix_queue_password_file: "/etc/postfix/sasl/passwd"
 postfix_queue_sender_canonical_maps_file: "/etc/postfix/sender_canonical_maps"
+postfix_queue_recipient_canonical_maps_file: "/etc/postfix/recipient_canonical_maps"
 postfix_queue_header_checks_file: "/etc/postfix/header_checks"
 
 postfix_queue_smtp_sasl_auth_enable: "yes"

--- a/playbooks/roles/postfix_queue/defaults/main.yml
+++ b/playbooks/roles/postfix_queue/defaults/main.yml
@@ -15,6 +15,10 @@ POSTFIX_QUEUE_EXTERNAL_SMTP_PORT: 587
 POSTFIX_QUEUE_EXTERNAL_SMTP_USER: ''
 POSTFIX_QUEUE_EXTERNAL_SMTP_PASSWORD: ''
 
+# Set this to the desired hostname.  It will also be used for origin, and
+# hence, as the domain when sending HELO/EHLO.
+POSTFIX_QUEUE_HOSTNAME: ''
+
 # Set this to content of sender_canonical_maps postfix configuration file (optional).
 # Example:
 # POSTFIX_QUEUE_SENDER_CANONICAL_MAPS: |-

--- a/playbooks/roles/postfix_queue/tasks/main.yml
+++ b/playbooks/roles/postfix_queue/tasks/main.yml
@@ -26,6 +26,13 @@
     - "sender_canonical_maps = hash:{{ postfix_queue_sender_canonical_maps_file }}"
     - "header_checks = regexp:{{ postfix_queue_header_checks_file }}"
 
+- name: Configure postfix hostname
+  command: postconf -e '{{ item }}'
+  with_items:
+    - "myhostname = {{ POSTFIX_QUEUE_HOSTNAME }}"
+    - "myorigin = {{ POSTFIX_QUEUE_HOSTNAME }}"
+  when: POSTFIX_QUEUE_HOSTNAME is defined and POSTFIX_QUEUE_HOSTNAME != ''
+
 - name: Explain postfix authentication
   lineinfile:
     dest: "{{ postfix_queue_password_file }}"

--- a/playbooks/roles/postfix_queue/tasks/main.yml
+++ b/playbooks/roles/postfix_queue/tasks/main.yml
@@ -24,6 +24,7 @@
     - "smtp_tls_security_level = {{ postfix_queue_smtp_tls_security_level }}"
     - "smtp_tls_mandatory_ciphers = {{ postfix_queue_smtp_tls_mandatory_ciphers }}"
     - "sender_canonical_maps = hash:{{ postfix_queue_sender_canonical_maps_file }}"
+    - "recipient_canonical_maps = hash:{{ postfix_queue_recipient_canonical_maps_file }}"
     - "header_checks = regexp:{{ postfix_queue_header_checks_file }}"
 
 - name: Configure postfix hostname
@@ -66,6 +67,20 @@
 - name: Hash postfix sender canonical maps file
   command: "postmap hash:{{ postfix_queue_sender_canonical_maps_file }}"
   when: postfix_queue_sender_canonical_maps.changed
+
+- name: Configure postfix recipient canonical maps
+  copy:
+    dest: "{{ postfix_queue_recipient_canonical_maps_file }}"
+    content: "# Configured by Ansible:\n{{ POSTFIX_QUEUE_RECIPIENT_CANONICAL_MAPS }}"
+    force: true
+    owner: root
+    group: root
+    mode: "0600"
+  register: postfix_queue_recipient_canonical_maps
+
+- name: Hash postfix recipient canonical maps file
+  command: "postmap hash:{{ postfix_queue_recipient_canonical_maps_file }}"
+  when: postfix_queue_recipient_canonical_maps.changed
 
 - name: Configure postfix header checks
   copy:


### PR DESCRIPTION
In analogy to the upstream-supported `POSTFIX_QUEUE_SENDER_CANONICAL_MAPS`, also add support for `POSTFIX_QUEUE_RECIPIENT_CANONICAL_MAPS` to facilitate things like sending email destined for `root` to a different address.

In addition, pull in the ability to set `myhostname` and `myorigin` from the `hastexo/juniper/postfix` branch where it doesn't really belong.