### PR TITLE
Optionally configure the deployment host with postfix_queue

### DIFF
--- a/playbooks/hastexo-multi-node.yml
+++ b/playbooks/hastexo-multi-node.yml
@@ -1,6 +1,14 @@
 ---
 # Example multi-node OpenStack deployment.
 
+- name: Configure deployment node
+  hosts: localhost
+  become: True
+  gather_facts: True
+  roles:
+    - role: postfix_queue
+      when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
+
 - name: Configure backend servers
   hosts: backend_servers
   become: True


### PR DESCRIPTION
If we are configured to run with an external Postfix mail host, we want to use that for email from the deployment node (`localhost`)
just like the app servers and backend nodes do.
