### PR TITLE
Update MariaDB playbooks to install v10.4

### DIFF
--- a/playbooks/roles/mariadb/defaults/main.yml
+++ b/playbooks/roles/mariadb/defaults/main.yml
@@ -14,7 +14,7 @@ MARIADB_APT_KEY_XENIAL_ID: '0xF1656F24C74CD1D8'
 MARIADB_APT_KEY_ID: '0xcbcb082a1bb943db'
 
 # Note: version is determined by repo
-MARIADB_REPO: "deb http://mirrors.syringanetworks.net/mariadb/repo/10.1/ubuntu {{ ansible_distribution_release }} main"
+MARIADB_REPO: "deb [arch=amd64,arm64,i386,ppc64el] http://mirror.23media.de/mariadb/repo/10.4/ubuntu {{ ansible_distribution_release }} main"
 
 MARIADB_CREATE_DBS: yes
 MARIADB_CLUSTERED: no


### PR DESCRIPTION
The Open EdX Koa release supports MySQL 5.7 and but still deploys
MariaDB 10.0 which is incompatible.
Update the playbooks to deploy MariaDB 10.4 and switch to a proper
mirror: mirror.23media.de
