### PR TITLE
Drop references to the postfix role

### DIFF
--- a/playbooks/hastexo-multi-node.yml
+++ b/playbooks/hastexo-multi-node.yml
@@ -18,8 +18,6 @@
     - mongo_3_6
     - elasticsearch
     - { role: 'mariadb', MARIADB_CREATE_DBS: 'yes' }
-    - role: postfix
-      when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST is not defined or POSTFIX_QUEUE_EXTERNAL_SMTP_HOST == ''
     - role: postfix_queue
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
     - memcache
@@ -55,8 +53,6 @@
     - certs
     - role: user_retirement_pipeline
       when: COMMON_RETIREMENT_SERVICE_SETUP
-    - role: postfix
-      when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST is not defined or POSTFIX_QUEUE_EXTERNAL_SMTP_HOST == ''
     - role: postfix_queue
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
     - guacd

--- a/playbooks/hastexo-single-node.yml
+++ b/playbooks/hastexo-single-node.yml
@@ -28,8 +28,6 @@
       update_users: True
     - certs
     - elasticsearch
-    - role: postfix
-      when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST is not defined or POSTFIX_QUEUE_EXTERNAL_SMTP_HOST == ''
     - role: postfix_queue
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
     - guacd


### PR DESCRIPTION
We haven't used this role in a while, and can use the upstream `postfix_queue` role instead.

