### PR TITLE
Switch from RabbitMQ to Redis

### DIFF
--- a/playbooks/hastexo-multi-node.yml
+++ b/playbooks/hastexo-multi-node.yml
@@ -23,13 +23,13 @@
     - memcache
 
 # RabbitMQ needs to be built serially
-- name: Configure RabbitMQ
+- name: Configure Redis
   hosts: backend_servers
   become: True
   gather_facts: True
   serial: 1
   roles:
-    - rabbitmq
+    - redis
 
 - name: Configure app servers
   hosts: app_servers:tmp_app_servers:app_master

--- a/playbooks/hastexo-single-node.yml
+++ b/playbooks/hastexo-single-node.yml
@@ -19,8 +19,7 @@
     - edxlocal
     - memcache
     - mongo_3_6
-    - role: rabbitmq
-      rabbitmq_ip: '127.0.0.1'
+    - role: redis
     - role: edxapp
       celery_worker: True
     - edxapp


### PR DESCRIPTION
Starting with the Koa release, the Open EdX platform has made the
switch from RabbitMQ to Redis. Update our playbooks to do the same.

