### PR TITLE
Update guacd role

### DIFF
--- a/playbooks/roles/guacd/defaults/main.yml
+++ b/playbooks/roles/guacd/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-guacd_version: 0.9.13-incubating
+guacd_version: 1.3.0
 guacd_mirror: http://archive.apache.org/dist

--- a/playbooks/roles/guacd/tasks/main.yml
+++ b/playbooks/roles/guacd/tasks/main.yml
@@ -1,21 +1,19 @@
 ---
 - name: Install requirements
   apt:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - build-essential
-    - libcairo2-dev
-    - libjpeg-turbo8-dev
-    - libpng12-dev
-    - libossp-uuid-dev
-    - libfreerdp-dev
-    - libpango1.0-dev
-    - libssh2-1-dev
-    - libvncserver-dev
-    - libssl-dev
-    - libwebp-dev
-    - freerdp
+    name:
+      - build-essential
+      - libcairo2-dev
+      - libjpeg-turbo8-dev
+      - libpng-dev
+      - libtool-bin
+      - libossp-uuid-dev
+      - libpango1.0-dev
+      - libssh2-1-dev
+      - libvncserver-dev
+      - libssl-dev
+      - libwebp-dev
+      - freerdp2-dev
 
 - name: Get server tarball
   get_url:


### PR DESCRIPTION
Bump the default guacd version to 1.3.0 and update the list of
dependencies accordingly.
(https://guacamole.apache.org/doc/1.3.0/gug/installing-guacamole.html#required-dependencies)
