### PR TITLE
Update variables for edx_django_async_service role

### DIFF
--- a/playbooks/roles/edx_django_async_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_async_service/tasks/main.yml
@@ -32,7 +32,7 @@
     - install:system-requirements
 
 - name: Pin pip to a specific version.
-  command: "{{ edx_django_async_service_venv_dir }}/bin/pip install pip=={{ common_pip_version }}"
+  command: "{{ edx_django_async_service_venv_dir }}/bin/pip install pip=={{ COMMON_PIP_VERSION }}"
   become_user: "{{ edx_django_async_service_user }}"
   tags:
     - install


### PR DESCRIPTION
Some variables have been redefined as uppercase for the Koa release.
We'll need to update common_pip_version to COMMON_PIP_VERSION
for our edx_django_async_service role.