### PR TITLE
Update suspender and reaper configuration files

### DIFF
--- a/playbooks/roles/hastexo_xblock/templates/reaper.conf.j2
+++ b/playbooks/roles/hastexo_xblock/templates/reaper.conf.j2
@@ -1,6 +1,6 @@
 [program:reaper]
 
-command=/edx/bin/python.edxapp {{ edxapp_code_dir }}/manage.py lms --settings={{ EDXAPP_SETTINGS }} reaper
+command={{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms --settings={{ EDXAPP_SETTINGS }} reaper
 
 user={{ common_web_user }}
 directory={{ edxapp_code_dir }}

--- a/playbooks/roles/hastexo_xblock/templates/suspender.conf.j2
+++ b/playbooks/roles/hastexo_xblock/templates/suspender.conf.j2
@@ -1,6 +1,6 @@
 [program:suspender]
 
-command=/edx/bin/python.edxapp {{ edxapp_code_dir }}/manage.py lms --settings={{ EDXAPP_SETTINGS }} suspender
+command={{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms --settings={{ EDXAPP_SETTINGS }} suspender
 
 user={{ common_web_user }}
 directory={{ edxapp_code_dir }}


### PR DESCRIPTION
The Koa release has dropped creating symlinks from the venv bin dir.
Use the link's target for python path directly instead.