### PR TITLE
Deploy Redis on app servers

### DIFF
--- a/playbooks/hastexo-multi-node.yml
+++ b/playbooks/hastexo-multi-node.yml
@@ -22,15 +22,6 @@
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
     - memcache
 
-# RabbitMQ needs to be built serially
-- name: Configure Redis
-  hosts: backend_servers
-  become: True
-  gather_facts: True
-  serial: 1
-  roles:
-    - redis
-
 - name: Configure app servers
   hosts: app_servers:tmp_app_servers:app_master
   become: True
@@ -45,6 +36,7 @@
       - xqueue
       nginx_default_sites:
       - lms
+    - role: redis
     - role: edxapp
       celery_worker: True
     - edxapp


### PR DESCRIPTION
We previously deployed RabbitMQ to backend servers to have multiple
nodes available for all Celery tasks.
Since the Koa release the Open EdX platform has switched RabbitMQ
for Redis and the expectation appears to be for Redis to be deployed
on app servers.
